### PR TITLE
top-down name resolution

### DIFF
--- a/src/Document.zig
+++ b/src/Document.zig
@@ -85,11 +85,13 @@ pub fn nodeRange(self: *@This(), node: u32) !lsp.Range {
 
 pub fn wordUnderCursor(self: *@This(), cursor: lsp.Position) []const u8 {
     const offset = self.utf8FromPosition(cursor);
+    const bytes = self.contents.items;
+
+    if (!isIdentifierChar(bytes[offset])) return "";
 
     var start = offset;
     var end = offset;
 
-    const bytes = self.contents.items;
     while (start > 0 and isIdentifierChar(bytes[start - 1])) start -= 1;
     while (end < bytes.len and isIdentifierChar(bytes[end])) end += 1;
 

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -618,6 +618,7 @@ fn externalDeclaration(p: *Parser) void {
     }
 
     typeQualifier(p);
+    const identifier_specifier = p.at(.identifier);
     if (p.atAny(type_specifier_first)) typeSpecifier(p);
 
     const m_field_list = p.open();
@@ -632,9 +633,7 @@ fn externalDeclaration(p: *Parser) void {
         return p.close(m, .block_declaration);
     }
 
-    if (p.eat(.@";")) return p.close(m, .qualifier_declaration);
-
-    if (p.at(.@",")) {
+    if (identifier_specifier and p.at(.@",")) {
         while (p.eat(.@",")) p.expect(.identifier);
         p.expect(.@";");
         return p.close(m, .qualifier_declaration);

--- a/src/syntax.zig
+++ b/src/syntax.zig
@@ -175,7 +175,10 @@ pub const Block = ListExtractor(.block, Token(.@"{"), Statement, Token(.@"}"));
 
 pub const Statement = union(enum) {
     pub usingnamespace UnionExtractorMixin(@This());
+    declaration: Declaration,
 };
+
+pub const ConditionList = ListExtractor(.condition_list, Token(.@"("), Statement, Token(.@")"));
 
 pub const Expression = Lazy("ExpressionUnion");
 

--- a/src/syntax.zig
+++ b/src/syntax.zig
@@ -201,6 +201,11 @@ pub fn Token(comptime tag: Tag) type {
         pub fn extract(_: Tree, node: u32, _: void) @This() {
             return .{ .node = node };
         }
+
+        pub fn text(self: @This(), source: []const u8, tree: Tree) []const u8 {
+            const span = tree.token(self.node);
+            return source[span.start..span.end];
+        }
     };
 }
 


### PR DESCRIPTION
Previously, name resolution worked by walking the parse tree upwards from the selected syntax node, returning any declarations it found in the upward traversal to the root. However, this caused various issues due to missing context about what the parent node was.

For example, in #25 it was found that field declarations were registered multiple times, since both the struct declaration and the field declaration itself registered the field.

Closes #25.