### PR TITLE
Fix parser defects

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,6 +18,8 @@ watch *ARGS:
 
 test:
     zig build test --summary failures {{flags}}
+    just install
+    tests/run-all-tests.sh
 
 test-file *ARGS:
     zig test {{flags}} "$@"

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -1324,8 +1324,8 @@ pub const Tokenizer = struct {
                 // decimal/octal
                 while (i < N and std.ascii.isDigit(text[i])) i += 1;
 
-                if (i < N and (text[i] == 'u' or text[i] == 'U')) {
-                    // unsigned (cannot be float)
+                if (i < N and std.mem.indexOfScalar(u8, "uUsSlL", text[i]) != null) {
+                    // integer suffix (unsigned, short, long)
                     i += 1;
                     return self.token(.number, i);
                 }

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -1350,9 +1350,7 @@ pub const Tokenizer = struct {
 
                 if (i < N and (text[i] == 'f' or text[i] == 'F')) {
                     i += 1;
-                } else if (i + 1 < N and (std.mem.startsWith(u8, text[i..], "lf") or
-                    std.mem.startsWith(u8, text[i..], "LF")))
-                {
+                } else if (std.ascii.startsWithIgnoreCase(text[i..], "lf")) {
                     i += 2;
                 }
 

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -1376,11 +1376,8 @@ pub const Tokenizer = struct {
                     while (i < N and std.ascii.isDigit(text[i])) i += 1;
                 }
 
-                if (i < N and (text[i] == 'f' or text[i] == 'F')) {
-                    i += 1;
-                } else if (std.ascii.startsWithIgnoreCase(text[i..], "lf")) {
-                    i += 2;
-                }
+                // type suffix (we just accept anything here to be as permissive as possible)
+                while (i < N and isIdentifierChar(text[i])) i += 1;
 
                 return self.token(.number, i);
             },


### PR DESCRIPTION
Fixes most of the defects found in #15.

The only remaining file which produces complaints is `tokenPaste.vert` which contains a bunch of edge cases for `#define`. We currently only accept macro expansion where declarations are allowed (e.g., `int foo`) as well as in expressions. However, in #30 I describe one approach for dealing with macros more generally in more positions.

Closes #15 (`tokenPaste.vert` is delegated to #30)