### PR TITLE
Allow hover one character past the end of identifiers

### DIFF
--- a/src/Document.zig
+++ b/src/Document.zig
@@ -84,13 +84,13 @@ pub fn nodeRange(self: *@This(), node: u32) !lsp.Range {
 }
 
 /// Return the node right under the cursor.
-pub fn tokenUnderCursor(self: *@This(), cursor: lsp.Position) !?u32 {
+pub fn identifierUnderCursor(self: *@This(), cursor: lsp.Position) !?u32 {
     const offset = self.utf8FromPosition(cursor);
     const parsed = try self.parseTree();
     const tree = parsed.tree;
 
     for (0.., tree.nodes.items(.tag), tree.nodes.items(.span)) |index, tag, span| {
-        if (tag.isToken() and span.start <= offset and offset < span.end) {
+        if (tag == .identifier and span.start <= offset and offset <= span.end) {
             return @intCast(index);
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -547,6 +547,12 @@ pub const Dispatch = struct {
 
         const token = try document.tokenBeforeCursor(params.value.position);
 
+        const parsed = try document.parseTree();
+        if (token != null and parsed.tree.tag(token.?) == .comment) {
+            // don't give completions in comments
+            return state.success(request.id, null);
+        }
+
         try completionsAtToken(
             state,
             document,

--- a/src/main.zig
+++ b/src/main.zig
@@ -645,7 +645,7 @@ pub const Dispatch = struct {
         const document = try getDocumentOrFail(state, request, params.value.textDocument);
         const parsed = try document.parseTree();
 
-        const token = try document.tokenUnderCursor(params.value.position) orelse {
+        const token = try document.identifierUnderCursor(params.value.position) orelse {
             return state.success(request.id, null);
         };
 
@@ -749,7 +749,7 @@ pub const Dispatch = struct {
         });
 
         const document = try state.workspace.getOrLoadDocument(params.value.textDocument);
-        const source_node = try document.tokenUnderCursor(params.value.position) orelse {
+        const source_node = try document.identifierUnderCursor(params.value.position) orelse {
             std.log.debug("no node under cursor", .{});
             return state.success(request.id, null);
         };


### PR DESCRIPTION
Allows hovers to be placed one character after the identifier, see https://github.com/nolanderc/glsl_analyzer/issues/26#issuecomment-1768668382.