### PR TITLE
allow nested field completions

### DIFF
--- a/src/syntax.zig
+++ b/src/syntax.zig
@@ -188,7 +188,14 @@ pub const ExpressionUnion = union(enum) {
     identifier: Token(.identifier),
     number: Token(.number),
     array: ArraySpecifier(Expression),
+    selection: Selection,
 };
+
+pub const Selection = Extractor(.selection, struct {
+    target: Expression,
+    @".": Token(.@"."),
+    field: Token(.identifier),
+});
 
 pub fn Token(comptime tag: Tag) type {
     comptime std.debug.assert(tag.isToken());


### PR DESCRIPTION
Fixes https://github.com/nolanderc/glsl_analyzer/issues/32#issuecomment-1769067058.

Also handles a few more edge cases, such completion after array access `foo[123].bar`