### PR TITLE
show extension information in hover documentation

### DIFF
--- a/src/Document.zig
+++ b/src/Document.zig
@@ -126,10 +126,6 @@ pub fn tokenBeforeCursor(self: *@This(), cursor: lsp.Position) !?u32 {
     return best;
 }
 
-fn isIdentifierChar(c: u8) bool {
-    return std.ascii.isAlphanumeric(c) or c == '_';
-}
-
 pub fn parseTree(self: *@This()) !*const CompleteParseTree {
     if (self.parse_tree) |*tree| return tree;
     self.parse_tree = try CompleteParseTree.parseSource(
@@ -142,8 +138,11 @@ pub fn parseTree(self: *@This()) !*const CompleteParseTree {
 pub const CompleteParseTree = struct {
     arena_state: std.heap.ArenaAllocator.State,
     tree: parse.Tree,
-    ignored: []parse.Token,
-    diagnostics: std.ArrayListUnmanaged(parse.Diagnostic),
+    ignored: []const parse.Token,
+    diagnostics: []const parse.Diagnostic,
+
+    // List of enabled extensions
+    extensions: []const []const u8,
 
     pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
         self.arena_state.promote(allocator).deinit();
@@ -153,22 +152,36 @@ pub const CompleteParseTree = struct {
         var arena = std.heap.ArenaAllocator.init(parent_allocator);
         errdefer arena.deinit();
 
-        const allocator = arena.allocator();
+        var diagnostics = std.ArrayList(parse.Diagnostic).init(arena.allocator());
 
-        var diagnostics = std.ArrayList(parse.Diagnostic).init(allocator);
         var ignored = std.ArrayList(parse.Token).init(parent_allocator);
         defer ignored.deinit();
 
-        const tree = try parse.parse(allocator, text, .{
+        const tree = try parse.parse(arena.allocator(), text, .{
             .ignored = &ignored,
             .diagnostics = &diagnostics,
         });
+
+        var extensions = std.ArrayList([]const u8).init(arena.allocator());
+        errdefer extensions.deinit();
+
+        for (ignored.items) |token| {
+            const line = text[token.start..token.end];
+            switch (parse.parsePreprocessorDirective(line) orelse continue) {
+                .extension => |extension| {
+                    const name = extension.name;
+                    try extensions.append(line[name.start..name.end]);
+                },
+                else => continue,
+            }
+        }
 
         return .{
             .arena_state = arena.state,
             .tree = tree,
             .ignored = tree.ignored(),
-            .diagnostics = diagnostics.moveToUnmanaged(),
+            .diagnostics = diagnostics.items,
+            .extensions = extensions.items,
         };
     }
 };


### PR DESCRIPTION
This offers an alternative solution to #1. Instead of limiting what is shown to the user, we make it obvious which extensions are needed for a function/variable.

One issue with the solution proposed in #1 (to hide items that don't have the  required extension isn't enabled) is that it reduces discoverability of items. This solution doesn't suffer from this, but does increase the noise in the completions somewhat.

Closes #1