### PR TITLE
Add hover and completion tests

### DIFF
--- a/tests/hover-and-completion/comments.frag
+++ b/tests/hover-and-completion/comments.frag
@@ -1,0 +1,31 @@
+#version 430 core
+
+// int
+// exp\
+vec4  \
+float \
+exp   \
+// exp\
+
+/*
+int foo(vec3);
+
+/*
+struct A {
+    int f1;
+} a;
+
+*/
+
+struct A {
+    float f1;
+} a;
+
+void main() {
+    a;    // <struct A { float f1; }>
+    A a;  // <struct A { float f1; }> <A>
+    a.f1; // a.<float>
+    /*
+    foo(vec3(1.0));
+    */
+}

--- a/tests/hover-and-completion/functions.frag
+++ b/tests/hover-and-completion/functions.frag
@@ -1,0 +1,61 @@
+#version 430 core
+
+int fun(inout int, out vec4, in float, const float);
+
+
+int fun_redeclared(int);
+int fun_redeclared(int);
+
+
+// Yeah, this breaks it if you do simple string comparison.
+// Same if you add const.
+int fun_redeclared_but_with_implicit_in(in int);
+int fun_redeclared_but_with_implicit_in(int);
+
+
+int  fun_overloaded(int);
+uint fun_overloaded(uint);
+
+// Another overload declared after main.
+// Should not be visible in main.
+int fun_overloaded_but_later(int);
+
+
+
+
+void main() {
+    int  inout_int;
+    vec4 out_vec4;
+    // <int (inout int, out vec4, in float, const float)>
+    fun(inout_int, out_vec4, 1.0, 1.0);
+
+    // <int (int)>
+    fun_redeclared(1);
+
+    // <int (in int)> OR <int (int)>, NOT BOTH
+    fun_redeclared_but_with_implicit_in(1);
+
+    // <int (int)> AND <uint (uint)>
+    fun_overloaded(1);
+
+    // <int (int)> (NO <uint (uint)>)
+    fun_overloaded_but_later(1);
+
+}
+
+
+
+
+int  fun_overloaded(int) { return 0; }
+uint fun_overloaded(uint) { return 0; }
+
+
+int  fun_redeclared(int) { return 0; }
+
+
+int  fun_redeclared_but_with_implicit_in(int) { return 0; }
+
+
+int  fun_overloaded_but_later(int) { return 0; }
+// This overload was not declared before main()
+uint fun_overloaded_but_later(uint) { return 0; }

--- a/tests/hover-and-completion/interface_blocks.geom
+++ b/tests/hover-and-completion/interface_blocks.geom
@@ -1,0 +1,82 @@
+#version 430 core
+
+layout (triangles) in;
+layout (triangle_strip, max_vertices = 36) out;
+
+in gl_PerVertex {
+    vec4  gl_Position;
+    float gl_PointSize;
+    float gl_ClipDistance[];
+} gl_in[];
+
+out gl_PerVertex {
+    vec4  gl_Position;
+    float gl_PointSize;
+    float gl_ClipDistance[];
+};
+
+
+struct Data {
+    int id;
+};
+
+in Interface {
+    Data data;
+    vec2 tex_coords;
+} in_[];
+
+out Interface {
+    vec4 frag_pos;
+    vec3 tex_coords; // vec3 for extra confusion
+} out_;
+
+
+struct Out {
+    vec4 frag_pos;
+    vec2 tex_coords;
+};
+
+out vec2 tex_coords;
+
+void main() {
+    for (int vert_id = 0; vert_id < 3; ++vert_id) {
+
+        // <out Interface { vec4 frag_pos; vec3 tex_coords; }> . <vec3>
+        out_.tex_coords =
+            // <in Interface { Data data; vec2 tex_coords; }[]> . <vec2>
+            vec3(in_[vert_id].tex_coords, 0.0);
+
+        // data: Data, id: int
+        if (vert_id == in_[vert_id].data.id) {}
+
+        // frag_pos: vec4
+        out_.frag_pos =
+            // gl_Position: vec4
+            gl_in[vert_id].gl_Position;
+
+
+        // Some shadowing tests
+        {
+            // <out vec2>
+            tex_coords =
+                // <out Interface { vec4 frag_pos; vec3 tex_coords; }> . <vec3>
+                out_.tex_coords.st;
+
+            // tex_coords: vec3
+            // Out <Out>
+            Out out_ =
+                // Out(<out Interface { ... }>, <out Interface { ... }>.st)
+                Out(out_.frag_pos, out_.tex_coords.st);
+
+            // gl_Position: vec4
+            gl_Position =
+                out_.frag_pos;
+
+            // <out vec2> = <Out> . <vec2>
+            tex_coords = out_.tex_coords;
+        }
+
+
+        EmitVertex();
+    }
+}

--- a/tests/hover-and-completion/shadowing.frag
+++ b/tests/hover-and-completion/shadowing.frag
@@ -1,0 +1,37 @@
+#version 430 core
+
+
+int       val;
+const int cval = 1;
+
+void main() {
+    val;  // int
+    cval; // const int
+
+    {
+        {
+            const int val = cval; // const int = const int
+        }
+        int cval = cval; // int = const int
+        {
+            cval; // int
+            val;  // int
+        }
+    }
+    cval; // const int
+    val;  // int
+
+
+    int       cval = val;  // int = int
+    const int val  = cval; // const int = int
+
+    val;  // const int
+    cval; // int
+
+}
+
+
+void foo(const int val, int cval) {
+    val;  // const int
+    cval; // int
+}

--- a/tests/hover-and-completion/struct_fields.frag
+++ b/tests/hover-and-completion/struct_fields.frag
@@ -1,0 +1,47 @@
+#version 430 core
+
+
+struct AAA {
+    int   f1;
+    float f2;
+    uint  fa; // Exclusive to AAA
+};
+
+struct BBB {
+    float f1;
+    int   f2;
+    bool  fb; // Exclusive to BBB
+};
+
+struct CCC {
+    AAA aaa; // To maybe confuse with globals
+    BBB bbb;
+    AAA  f1;
+    BBB  f2;
+};
+
+
+const AAA aaa = AAA(1, 1.0, 1);
+const BBB bbb = BBB(1.0, 1, true);
+const CCC ccc = CCC(aaa, bbb, aaa, bbb);
+
+
+void foo() {
+    aaa; // const AAA
+    bbb; // const BBB
+    ccc; // const CCC
+
+    // Single subfield expansion
+    aaa.f1; // int
+    bbb.f1; // float
+    ccc.f1; // AAA
+
+    // Nested subfield expansion
+    ccc.aaa.f1; // int
+    ccc.aaa.f2; // float
+    ccc.aaa.fa; // uint
+    ccc.bbb.f1; // float
+    ccc.bbb.f2; // int
+    ccc.bbb.fb; // bool
+}
+

--- a/tests/lsp_testing_input.py
+++ b/tests/lsp_testing_input.py
@@ -1,0 +1,193 @@
+import pathlib
+
+from testing_utils import (
+    ExpectFail,
+    FileToTest,
+    TokenKind
+)
+
+
+
+
+base_directory = pathlib.Path(__file__).parent.resolve()
+
+
+
+files = [
+    # TODO: Arrays, UBOs and SSBOs, images/samplers.
+    FileToTest(
+        path="glsl-samples/well-formed/basic.vert",
+        hover_test_args=(
+            (18, 19, "const vec4"),
+            (20, 20, "Rectangle[4]"),
+            (24, 13, "void (int)"),
+            (35, 13, "vec3"),
+        )
+    ),
+    FileToTest(
+        path="hover-and-completion/shadowing.frag",
+        hover_test_args=(
+            # Globals.
+            ( 4, 11, "int"),
+            ( 5, 11, "const int"),
+            ( 8,  5, "int"),
+            ( 9,  5, "const int"),
+            # Shadowed by locals.
+            (13, 23, "const int"),
+            (13, 29, "const int"),
+            # Self-shadowing (same name, different type).
+            (15, 13, "int"),
+            (15, 20, "const int"),
+            # Correctly recover scope.
+            (17, 13, "int"),
+            (18, 13, "int"),
+            (21,  5, "const int"),
+            (22,  5, "int"),
+            # Swap types in scope.
+            (25, 15, "int"),
+            (25, 22, "int"),
+            (26, 15, "const int"),
+            (26, 22, "int"),
+            (28,  5, "const int"),
+            (29,  5, "int"),
+            # Shadowing by function parameter names.
+            (35,  5, "const int"),
+            (36,  5, "int"),
+        )
+    ),
+    FileToTest(
+        path="hover-and-completion/struct_fields.frag",
+        hover_test_args=(
+            # Globals.
+            (30,  5, "const AAA"),
+            (31,  5, "const BBB"),
+            (32,  5, "const CCC"),
+            # Fields of structs.
+            (35,  9, "int"),
+            (36,  9, "float"),
+            (37,  9, "AAA"),
+            # Fields of fields of structs.
+            (40, 13, "int"),
+            (41, 13, "float"),
+            (42, 13, "uint"),
+            (43, 13, "float"),
+            (44, 13, "int"),
+            (45, 13, "bool"),
+        ),
+        completion_test_args=(
+            # Correctly list fields of a struct.
+            (35,  9, ("f1", "f2", "fa")),
+            (36,  9, ("f1", "f2", "fb")),
+            (37,  9, ("f1", "f2", "aaa", "bbb")),
+            # Correctly list fields of a field of a struct.
+            (40, 13, ("f1", "f2", "fa")),
+            (43, 13, ("f1", "f2", "fb")),
+        )
+    ),
+    FileToTest(
+        path="hover-and-completion/interface_blocks.geom",
+        hover_test_args=(
+            # Correct named interface types and their fields.
+            (45,  9, "out Interface { vec4 frag_pos; vec3 tex_coords; }"),
+            (45, 14, "vec3"),
+            (47, 18, "in Interface { Data data; vec2 tex_coords; }[]"),
+            (47, 31, "vec2"),
+            # Field of a field of a named interface block.
+            (50, 37, "Data"),
+            (50, 42, "int"),
+            # Correct type of explicitly declared input params.
+            (53, 14, "vec4"),
+            (55, 28, "vec4"),
+            # Check for no confusion between the same names.
+            (61, 13, "out vec2"),
+            (63, 17, "out Interface { vec4 frag_pos; vec3 tex_coords; }"),
+            (63, 22, "vec3"),
+            # Shadowing an interface with a similar struct.
+            (67, 17, "Out"),
+            (69, 21, "out Interface { vec4 frag_pos; vec3 tex_coords; }"),
+            # Possible confusion on type of tex_coords between `struct Out` and `out Interface`.
+            (69, 41, "vec3"),
+            # Correct type of explicitly declared output params.
+            (72, 13, "vec4"),
+            # More possible name confusion on `tex_coords`.
+            (76, 13, "out vec2"),
+            (76, 26, "Out"),
+            (76, 31, "vec2"),
+        ),
+        completion_test_args=(
+            # Fields of the interface blocks are resolved correctly.
+            (45, 14, ("frag_pos", "tex_coords")),
+            (47, 31, ("data", "tex_coords")),
+            # Field of a fild of a named interface block.
+            (50, 42, ("id",)),
+            # Fields of the redeclared default input block.
+            (55, 28, ("gl_ClipDistance", "gl_Position", "gl_PointSize")),
+            # Primitive types have no fields.
+  ExpectFail(63, 33, None, \
+                reason="Undesirable behavior. Although works correctly for blocks and structs."),
+        ),
+    ),
+    FileToTest(
+        path="hover-and-completion/functions.frag",
+        hover_test_args=(
+            # Basic function declaration with qualified argument types.
+            (30,  5, "int (inout int, out vec4, in float, const float)", TokenKind.Function),
+            # Redeclaration of the same signature should not produce duplicate info.
+            (33,  5, "int (int)", TokenKind.Function),
+            # Redeclaration with implicit `in` or `const` qualifier should not produce extra overloads.
+  ExpectFail(36,  5, "int (int)", TokenKind.Function, \
+                reason="Current version uses simple string comparison for removing overloads"),
+            # Functions from visible overload set are present.
+            (39,  5, {"int (int)", "uint (uint)"}, TokenKind.Function),
+            # Overloads inaccessble in the current context should not be visible.
+  ExpectFail(42,  5, "int (int)", TokenKind.Function, \
+                reason="Bug. Should only show overloads declared previously"),
+        ),
+        completion_test_args=(
+            # Basic function identifier presence.
+            (30,  8, ("fun",), TokenKind.Function),
+            # No duplicate completion entries on redeclaration.
+            (33,  8, ("fun_redeclared",), TokenKind.Function),
+            # Redeclaration with implicit `in` or `const` qualifier should not produce extra overloads.
+  ExpectFail(36,  8, ("fun_redeclared_but_with_implicit_in",), TokenKind.Function, \
+                reason="Current version does not remove duplicate overloads from the completion list"),
+            # Overloads do not generate duplicate entries in the completion list.
+  ExpectFail(39,  8, ("fun_overloaded",), TokenKind.Function, \
+                reason="Current version does not remove duplicate overloads from the completion list"),
+            # Inaccessible overload should not be visible.
+  ExpectFail(42,  8, ("fun_overloaded_but_later",), TokenKind.Function, \
+                reason="Bug. Inaccessible overloads are visible in completion")
+        ),
+    ),
+    FileToTest(
+        path="hover-and-completion/comments.frag",
+        hover_test_args=(
+            # Hover in comments should return nothing.
+            ( 3,  4, None),
+            ( 4,  4, None),
+            ( 5,  1, None),
+            ( 6,  1, None),
+            ( 7,  1, None),
+            ( 8,  4, None),
+            (11,  8, None),
+            (16,  3, None),
+            # Commented out definitions should not confuse hover info.
+            (25,  5, "struct A { float f1; }"),
+            (26,  5, "struct A { float f1; }"),
+            (26,  7, "A"),
+            (27,  7, "float"),
+            (29,  5, None),
+        ),
+        completion_test_args=(
+            # Completion in comments should be disabled.
+            ( 3,  7, None),
+            ( 4,  7, None),
+            ( 5,  5, None),
+            ( 6,  6, None),
+            ( 7,  4, None),
+            ( 8,  7, None),
+            (29,  8, None),
+        )
+    ),
+]
+

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-lsp
+pytest-subtests

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,0 +1,210 @@
+import os
+import pathlib
+import re
+
+import lsprotocol.types as lspt
+
+import pytest
+import pytest_subtests
+import pytest_lsp
+
+
+base_directory = pathlib.Path(__file__).parent.resolve()
+
+
+
+class ExpectFail:
+    """A wrapper class that signals that a test with
+    this particular set of arguments is expected to fail"""
+    def __init__(self, args):
+        self.args = args
+
+
+def unwrap_args(args):
+    """Removes top-level `ExpectFail` if present
+    and returns a boolean indicating whether
+    success is expected as a last tuple element"""
+    if isinstance(args, ExpectFail):
+        return (*args.args, False)
+    else:
+        return (*args, True)
+
+
+class FileToTest:
+    HoverExpectedType = str|None
+    HoverTestArgs     = tuple[int, int, HoverExpectedType]
+
+    def __init__(
+        self,
+        path: str,
+        hover_test_args: tuple[HoverTestArgs|ExpectFail] = (),
+    ):
+        self.path = path
+        self.hover_test_args = hover_test_args
+
+
+
+
+
+files = [
+    FileToTest(
+        path="glsl-samples/well-formed/basic.vert",
+        hover_test_args=(
+            (18, 19, "const vec4"),
+            (20, 20, "Rectangle[4]"),
+            (24, 13, "void (int)"),
+            (35, 13, "vec3"),
+        )
+    ),
+    FileToTest(
+        path="glsl-samples/hover/shadowing.frag",
+        hover_test_args=(
+            ( 4, 11, "int"),
+            ( 5, 11, "const int"),
+            ( 8,  5, "int"),
+            ( 9,  5, "const int"),
+            (13, 23, "const int"),
+            (13, 29, "const int"),
+            (15, 13, "int"),
+            ExpectFail((15, 20, "const int")),
+            (21,  5, "const int"),
+            (22,  5, "int"),
+            (25, 15, "int"),
+            (25, 22, "int"),
+            (26, 15, "const int"),
+            (26, 22, "int"),
+            (28,  5, "const int"),
+            (29,  5, "int"),
+            (35,  5, "const int"),
+            (36,  5, "int"),
+        )
+    ),
+    FileToTest(
+        path="glsl-samples/hover/struct_fields.frag",
+        hover_test_args=(
+            (30,  5, "const AAA"),
+            (31,  5, "const BBB"),
+            (32,  5, "const CCC"),
+            (35,  9, "int"),
+            (36,  9, "float"),
+            (37,  9, "AAA"),
+            ExpectFail((40, 13, "int")),
+            ExpectFail((41, 13, "float")),
+            ExpectFail((42, 13, "uint")),
+            ExpectFail((43, 13, "float")),
+            ExpectFail((44, 13, "int")),
+            ExpectFail((45, 13, "bool")),
+        )
+    )
+]
+
+
+
+
+
+
+
+# This is just setup.
+@pytest_lsp.fixture(
+    config=pytest_lsp.ClientServerConfig(
+        server_command=["glsl_analyzer", "--stdio", "--clientProcessId", str(os.getpid())]
+    )
+)
+async def client(lsp_client: pytest_lsp.LanguageClient):
+    params = lspt.InitializeParams(
+        capabilities=lspt.ClientCapabilities(),
+        process_id=os.getpid()
+    )
+    await lsp_client.initialize_session(params)
+    yield
+    await lsp_client.shutdown_session()
+
+
+
+
+class OpenedFile:
+    def __init__(self, file: FileToTest, identifier: lspt.TextDocumentIdentifier):
+        self.file       = file
+        self.identifier = identifier
+
+    def __str__(self) -> str:
+        return self.file.path
+
+
+
+@pytest.fixture(params=files)
+def opened_file(client: pytest_lsp.LanguageClient, request):
+    file: FileToTest = request.param
+    fullpath         = base_directory / file.path
+
+    with open(fullpath, "r") as file_handle:
+        source = file_handle.read()
+
+    this_doc = lspt.TextDocumentItem(
+        uri=f"file://{fullpath}",
+        language_id="glsl",
+        version=0,
+        text=source
+    )
+
+    this_doc_id = lspt.TextDocumentIdentifier(
+        uri=this_doc.uri
+    )
+
+    client.text_document_did_open(
+        lspt.DidOpenTextDocumentParams(this_doc)
+    )
+
+    yield OpenedFile(file, this_doc_id)
+
+    client.text_document_did_close(
+        lspt.DidCloseTextDocumentParams(this_doc_id)
+    )
+
+
+
+
+
+def to_zero_based_position(line: int, column: int) -> lspt.Position:
+    return lspt.Position(line - 1, column -1)
+
+def strip_md(mdtext: lspt.MarkupContent) -> str:
+    text = mdtext.value
+    text = re.sub("```glsl\n", "", text)
+    text = re.sub("\n```",     "", text)
+    return text
+
+
+
+@pytest.mark.asyncio
+async def test_hover(
+    client: pytest_lsp.LanguageClient,
+    opened_file: OpenedFile,
+    subtests: pytest_subtests.SubTests
+):
+
+    for hover_args in opened_file.file.hover_test_args:
+        line, column, expected, expect_success = unwrap_args(hover_args)
+        file_location = f"{opened_file}:{line}:{column}"
+
+        with subtests.test(msg=file_location):
+
+            result = await client.text_document_hover_async(
+                params=lspt.HoverParams(
+                    text_document=opened_file.identifier,
+                    position=to_zero_based_position(line, column)
+                )
+            )
+
+            if result is not None:
+                result = strip_md(result.contents)
+
+            if expect_success:
+                assert result == expected
+            else: # expect fail
+                # Ohh, how much do I not like this...
+                assert result != expected, "Expected to fail, passed instead"
+                pytest.xfail(file_location)
+
+
+

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,0 +1,131 @@
+import typing
+from enum import Enum
+
+import lsprotocol.types as lspt
+
+
+class ExpectFail:
+    """A wrapper class that signals that a test with
+    this particular set of arguments is expected to fail"""
+    def __init__(self, *args, reason: str="(No Reason Specified)"):
+        self.args   = args
+        self.reason = reason
+
+
+class TokenKind(Enum):
+    """Enum used for differentiating between formats
+    of hover info, completion results, etc.
+
+    The interpretation of the `expected` parameter changes
+    based on the supplied `TokenKind`.
+
+    Most of the time the default `Other` kind is enough,
+    but some kinds like `Function` require special handling
+    because of overloads, for example."""
+
+    Other = 0
+    """Default token kind with no special testing semantics.
+
+    For hover:
+        `expected` is `str|None`.
+        Compares stripped version of result with `expected`.
+
+    For completion:
+        `expected` is `tuple[str]|None`.
+        Checks if all the elements of `expected` are uniquely present in
+        the completion list."""
+
+    Function = 1
+    """Special token kind capable of handling the function overloads.
+
+    For hover:
+        `expected` is `str|set[str]|None`.
+        Checks that each overload of the `expected` set is present
+        in the stripped result.
+
+    For completion:
+        Same as `Other`."""
+
+
+class HoverTestArgs:
+    def __init__(
+        self,
+        line: int, column: int,
+        expected,
+        token_kind: TokenKind = TokenKind.Other,
+        *,
+        _expect_fail: bool = False,
+        _expect_fail_reason: str = ""
+    ):
+        self.args = (
+            line, column, expected, token_kind,
+            _expect_fail, _expect_fail_reason
+        )
+
+    def __iter__(self):
+        return self.args.__iter__()
+
+
+class CompletionTestArgs:
+    def __init__(
+        self,
+        line: int, column: int,
+        expected,
+        token_kind: TokenKind = TokenKind.Other,
+        *,
+        _expect_fail: bool = False,
+        _expect_fail_reason: str = ""
+    ):
+        self.args = (
+            line, column, expected, token_kind,
+            _expect_fail, _expect_fail_reason
+        )
+
+    def __iter__(self):
+        return self.args.__iter__()
+
+
+def _unwrap_args(
+    args_type: type[HoverTestArgs|CompletionTestArgs],
+    args: tuple|ExpectFail
+):
+    """Removes top-level `ExpectFail` if present
+    and packs the args tuple into the specified `args_type`
+    along with the `expect_fail` info."""
+    if isinstance(args, ExpectFail):
+        return args_type(
+            *args.args,
+            _expect_fail=True,
+            _expect_fail_reason=args.reason
+        )
+    elif isinstance(args, tuple):
+        return args_type(*args)
+    else:
+        raise TypeError(
+            "Expected tuple or an instance of ExpectArgs."
+        )
+
+
+class FileToTest:
+    def __init__(
+        self,
+        path: str,
+        hover_test_args: tuple[tuple|ExpectFail] = (),
+        completion_test_args: tuple[tuple|ExpectFail] = (),
+    ):
+        self.path                 = path
+        self.hover_test_args      = \
+            tuple(_unwrap_args(HoverTestArgs, args) for args in hover_test_args)
+        self.completion_test_args = \
+            tuple(_unwrap_args(CompletionTestArgs, args) for args in completion_test_args)
+
+
+class OpenedFile:
+    def __init__(self, file: FileToTest, identifier: lspt.TextDocumentIdentifier):
+        self.file       = file
+        self.identifier = identifier
+
+    def __str__(self) -> str:
+        return self.file.path
+
+


### PR DESCRIPTION
This PR implements a mini testing framework for hover and autocomplete for glsl_analyzer. It is based on `pytest` and `pytest-lsp` packages. Some points about the design:

- The tests and are defined as *expectations* that are matched against the *result* received from an LSP request;
- The exact testing logic and interpretation of expectations depends on the request and the *type of token* being inspected;
- Tests can be marked as "expected to fail" in strict mode (if it's expected to fail, succeeding is an error);

Should help resolve #26.

---

@nolanderc, please review this one. 

Start with `lsp_testing_input.py`, it shows how you define tests in terms of expectations. Take note of how `ExpectFail` and `TokenKind` are used to control the flow of tests. Then move on to `testing_utils.py` to see the primitives used for wrapping data and communicating testing conditions. Lastly, `test_lsp.py` contains the testing logic itself, arguably the ugliest part of this whole thing, but it has to be written once at best per request type/token combination.

---

I also added the glsl samples that I wrote for these tests into this repo as part of the PR. I realized that submodules are probably not the best idea for the type of workflow these tests aiming at. Updating the tests with submodules happens in the following steps:
1. Update tests on a local fork/branch of glsl-samples
2. Submit a PR for glsl-samples 
3. Accept the submitted PR
4. Pull the glsl-samples submodule in the local branch of the glsl_analyzer
5. Commit the submodule update and push
6. Submit a PR for glsl_analyzer with the new tests.

Now imagine that in the process of this glsl_analyzer PR a bug was found; we fixed it, and we now want to add a test for that bug as part of that PR. We have to do steps 1-5 again. This is cumbersome and this will come up every time we want to update the tests. Also, if the CI is set-up to run the tests, you are always forced to update them; even if it is a bugfix, you'd have to remove `ExpectFail`.

I suggest that we keep most of the tests we write in this repo and reserve glsl-samples for tests that we *dump* with no intention to modify/extend them frequently.
