### PR TITLE
feat: update to zig-0.14

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -126,7 +126,7 @@ const CompressStep = struct {
         return .{ .generated = .{ .file = &self.generated_file } };
     }
 
-    fn make(step: *std.Build.Step, _: std.Progress.Node) anyerror!void {
+    fn make(step: *std.Build.Step, _: std.Build.Step.MakeOptions) anyerror!void {
         const b = step.owner;
         const self: *@This() = @fieldParentPtr("step", step);
         const input_path = self.input.getPath(b);

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -265,7 +265,7 @@ pub fn visibleFields(
 
         var remaining_iterations: u32 = 16;
 
-        while (references.popOrNull()) |reference| {
+        while (references.pop()) |reference| {
             if (remaining_iterations == 0 or references.items.len >= 128) break;
             remaining_iterations -= 1;
 

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -445,7 +445,7 @@ pub const Parser = struct {
         return tree;
     }
 
-    fn deferError(self: *@This(), value: anytype) @typeInfo(@TypeOf(value)).ErrorUnion.payload {
+    fn deferError(self: *@This(), value: anytype) @typeInfo(@TypeOf(value)).error_union.payload {
         if (value) |success| {
             return success;
         } else |err| {

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -416,7 +416,7 @@ pub const Parser = struct {
     pub fn finish(self: *@This()) !Tree {
         if (self.deferred_error) |err| return err;
 
-        try self.tree.nodes.append(self.allocator, self.stack.pop());
+        try self.tree.nodes.append(self.allocator, self.stack.pop().?);
         self.tree.assignParents();
 
         var tree = self.tree;

--- a/src/syntax.zig
+++ b/src/syntax.zig
@@ -234,7 +234,7 @@ pub fn Extractor(comptime expected_tag: Tag, comptime T: type) type {
         }
 
         const MatchFields = @Type(.{
-            .Struct = .{
+            .@"struct" = .{
                 .layout = .auto,
                 .fields = blk: {
                     var match_fields: [fields.len]std.builtin.Type.StructField = undefined;
@@ -389,7 +389,7 @@ pub fn UnionExtractorMixin(comptime Self: type) type {
         pub usingnamespace ExtractorMixin(Self);
 
         const MatchUnion = @Type(.{
-            .Union = .{
+            .@"union" = .{
                 .layout = .auto,
                 .fields = blk: {
                     var match_fields: [fields.len]std.builtin.Type.UnionField = undefined;
@@ -487,8 +487,8 @@ pub fn Lazy(comptime type_name: []const u8) type {
 }
 
 pub fn MatchResult(comptime T: type) type {
-    const match_fn_return = @typeInfo(@TypeOf(T.match)).Fn.return_type.?;
-    return @typeInfo(match_fn_return).Optional.child;
+    const match_fn_return = @typeInfo(@TypeOf(T.match)).@"fn".return_type.?;
+    return @typeInfo(match_fn_return).optional.child;
 }
 
 pub fn ExtractorMixin(comptime Self: type) type {

--- a/src/syntax.zig
+++ b/src/syntax.zig
@@ -241,7 +241,7 @@ pub fn Extractor(comptime expected_tag: Tag, comptime T: type) type {
                     for (&match_fields, fields) |*match_field, field| {
                         match_field.* = field;
                         match_field.type = Match(field.type);
-                        match_field.default_value = &@as(match_field.type, .{});
+                        match_field.default_value_ptr = &@as(match_field.type, .{});
                     }
                     break :blk &match_fields;
                 },

--- a/src/util.zig
+++ b/src/util.zig
@@ -40,7 +40,7 @@ pub fn normalizePath(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     while (components.next()) |component| {
         if (std.mem.eql(u8, component.name, "..")) {
             while (buffer.items.len > components.root_end_index) {
-                if (std.fs.path.isSep(buffer.pop())) break;
+                if (std.fs.path.isSep(buffer.pop().?)) break;
             }
         } else if (std.mem.eql(u8, component.name, ".")) {
             continue;


### PR DESCRIPTION
Update to Zig 0.14.

Most changes involve straightforward renames of standard library types.

The only nontrivial change is regarding `pop`. Based on my understanding:
- In 0.13, calling `pop()` on an empty collection would panic.
 - In 0.14, `popOrNull()` has been renamed to `pop()`, which now returns an optional value. Using `pop().?` will also panic if the value is null.
 
Therefore, migrating from `pop()` in 0.13 to `pop().?` in 0.14 should preserve the original behavior. However, I'm not very knowledgable about Zig so I recommend verifying this to ensure accuracy.