### PR TITLE
feat: publish diagnostics

### DIFF
--- a/src/jsonrpc.zig
+++ b/src/jsonrpc.zig
@@ -74,3 +74,24 @@ pub const JsonPreformatted = struct {
         try jw.print("{s}", .{self.raw});
     }
 };
+
+pub const Notification = struct {
+    jsonrpc: []const u8 = "2.0",
+    method: []const u8,
+    params: JsonPreformatted,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.beginObject();
+
+        try jw.objectField("jsonrpc");
+        try jw.write(self.jsonrpc);
+
+        try jw.objectField("method");
+        try jw.write(self.method);
+
+        try jw.objectField("params");
+        try jw.write(self.params);
+
+        try jw.endObject();
+    }
+};

--- a/src/lsp.zig
+++ b/src/lsp.zig
@@ -162,3 +162,44 @@ pub const Location = struct {
     uri: []const u8,
     range: Range,
 };
+
+pub const Diagnostic = struct {
+    range: Range,
+    severity: ?DiagnosticSeverity = null,
+    code: ?[]const u8 = null,
+    source: ?[]const u8 = "glsl_analyzer",
+    message: []const u8,
+    tags: ?[]DiagnosticTag = null,
+    relatedInformation: ?[]DiagnosticRelatedInformation = null,
+};
+
+pub const DiagnosticSeverity = enum(u8) {
+    @"error" = 1,
+    warning = 2,
+    information = 3,
+    hint = 4,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
+};
+
+pub const DiagnosticTag = enum(u8) {
+    unnecessary = 1,
+    deprecated = 2,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
+};
+
+pub const DiagnosticRelatedInformation = struct {
+    location: Location,
+    message: []const u8,
+};
+
+pub const PublishDiagnosticsParams = struct {
+    uri: []const u8,
+    version: ?i64 = null,
+    diagnostics: []const Diagnostic,
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -413,13 +413,8 @@ const State = struct {
         var parse_diagnostics = std.ArrayList(parse.Diagnostic).init(self.allocator);
         defer parse_diagnostics.deinit();
 
-        var tree = parse.parse(self.allocator, document.source(), .{
-            .diagnostics = &parse_diagnostics,
-        }) catch |err| {
-            std.log.warn("failed to re-parse for diagnostics: {}", .{err});
-            return;
-        };
-        defer tree.deinit(self.allocator);
+        const parsed: *const Workspace.Document.CompleteParseTree = try document.parseTree();
+        try parse_diagnostics.appendSlice(parsed.diagnostics);
 
         // Convert parser diagnostics to LSP diagnostics
         const lsp_diagnostics = try self.allocator.alloc(lsp.Diagnostic, parse_diagnostics.items.len);


### PR DESCRIPTION
Publish diagnostics to the frontend.  I've never programmed Zig before so let me know if I did anything heinous here.  Also did have Claude help me here so might be a bit sloppy. I cleaned up the major issues I saw it produce (e.g. parsing the tree multiple times in a row to publish the diagnostics).  Was thinking of just having the Notification just be a specialized `id: null` field of Request but that [appears to be discouraged by the spec](https://www.jsonrpc.org/specification).

This should resolve issue [63](https://github.com/nolanderc/glsl_analyzer/issues/63).  I did see you mention a queueing system for the notifs that I didn't get around to implementing.  Let me know if that's necessary

What it looks like in Emacs: 
<img width="1725" height="955" alt="image" src="https://github.com/user-attachments/assets/47fc16f3-7e51-40af-8281-0353ee58db1f" />
